### PR TITLE
Split parser by architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 /.vscode
 /cpm_modules
 .DS_Store
+
+# Eclipse files
+.cproject
+.project
+.settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,7 @@ endif()
 include(cmake/CPM.cmake)
 
 find_package(Dyninst REQUIRED)
-include_directories(DYNINST_INCLUDE_DIRS)
-link_directories(DYNINST_LIBRARIES)
-
+find_package(Boost REQUIRED)
 
 # PackageProject.cmake will be used to make our target installable
 CPMAddPackage("gh:TheLartians/PackageProject.cmake@1.6.0")
@@ -52,16 +50,15 @@ add_library(Smeagle ${headers} ${sources})
 
 set_target_properties(Smeagle PROPERTIES CXX_STANDARD 17)
 
-# being a cross-platform target, we enforce standards conformance on MSVC
-target_compile_options(Smeagle PUBLIC "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/permissive->")
-
 # Link dependencies
-target_link_libraries(Smeagle PRIVATE fmt::fmt symtabAPI common instructionAPI)
+target_link_libraries(Smeagle PRIVATE fmt::fmt Boost::boost common symtabAPI)
 
 target_include_directories(
-  Smeagle PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-                 $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+  Smeagle
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+         $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}> ${Boost_INCLUDE_DIRS}
 )
+target_include_directories(Smeagle PUBLIC ${DYNINST_INCLUDE_DIR})
 
 # ---- Create an installable target ----
 # this allows users to install and find the library via `find_package()`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,17 +36,20 @@ CPMAddPackage(
 )
 
 # ---- Add source files ----
-
-# Note: globbing sources is considered bad practice as CMake's generators may not detect new files
-# automatically. Keep that in mind when changing files, or explicitly mention them here.
-file(GLOB_RECURSE headers CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h")
-file(GLOB_RECURSE sources CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/source/*.cpp")
+set(include_dirs
+	smeagle/include
+	source/detail
+)
+set(sources
+	source/corpora.cpp
+	source/smeagle.cpp
+	source/detail/parser/x86_64.cpp
+	source/detail/parser/ppc64le.cpp
+	source/detail/parser/aarch64.cpp
+)
 
 # ---- Create library ----
-
-# Note: for header-only libraries change all PUBLIC flags to INTERFACE and create an interface
-# target: add_library(Smeagle INTERFACE)
-add_library(Smeagle ${headers} ${sources})
+add_library(Smeagle ${sources})
 
 set_target_properties(Smeagle PROPERTIES CXX_STANDARD 17)
 
@@ -56,9 +59,11 @@ target_link_libraries(Smeagle PRIVATE fmt::fmt Boost::boost common symtabAPI)
 target_include_directories(
   Smeagle
   PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-         $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}> ${Boost_INCLUDE_DIRS}
+         $<INSTALL_INTERFACE:include/${PROJECT_NAME}-${PROJECT_VERSION}>
+         ${Boost_INCLUDE_DIRS}
+         ${include_dirs}
+         ${DYNINST_INCLUDE_DIR}
 )
-target_include_directories(Smeagle PUBLIC ${DYNINST_INCLUDE_DIR})
 
 # ---- Create an installable target ----
 # this allows users to install and find the library via `find_package()`.

--- a/include/smeagle/TypeLocation.h
+++ b/include/smeagle/TypeLocation.h
@@ -1,0 +1,17 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#pragma once
+
+// A type location has a name, type, export/import, and location
+struct TypeLocation {
+	std::string name;
+	std::string parent;
+	std::string type;
+	std::string reg;
+	std::string exportOrImport;
+	std::string locoffset;
+	std::string location;
+};

--- a/include/smeagle/corpora.h
+++ b/include/smeagle/corpora.h
@@ -10,21 +10,9 @@
 #include "Function.h"
 #include "Symtab.h"
 
-using namespace Dyninst;
-using namespace SymtabAPI;
+#include "smeagle/TypeLocation.h"
 
 namespace smeagle {
-
-  // A type location has a name, type, export/import, and location
-  struct TypeLocation {
-    std::string name;
-    std::string parent;
-    std::string type;
-    std::string reg;
-    std::string exportOrImport;  
-    std::string locoffset;
-    std::string location;
-  };
 
   // A register class for AMD64 is defined on page 16 of the System V abi pdf
   enum RegisterClass {    

--- a/include/smeagle/corpora.h
+++ b/include/smeagle/corpora.h
@@ -6,26 +6,13 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
-#include "Function.h"
 #include "Symtab.h"
 
 #include "smeagle/TypeLocation.h"
 
 namespace smeagle {
-
-  // A register class for AMD64 is defined on page 16 of the System V abi pdf
-  enum RegisterClass {    
-    INTEGER,     // Integer types that fit into one of the general purpose registers    
-    SSE,         // Types that fit into an SSE register
-    SSEUP,       // ^.. and can ve passed and returned in he most significant half of it
-    X87,         // Types that will be returned via the x87 FPU
-    X87UP,       // ^
-    COMPLEX_X87, // Types that will be returned via the x87 FPU
-    NO_CLASS,    // Initalizer in the algorithms, used for padding and empty
-                 // tructures and unions
-    MEMORY       // Types that will be passed and returned in memory via the stack
-  };
 
   /**
    * @brief A class for holding corpus metadata
@@ -44,7 +31,7 @@ namespace smeagle {
      * @brief Parse a function symbol into parameters, types, locations
      * @param symbol the symbol that is determined to be a function
      */
-    void parseFunctionABILocation(Symbol *symbol);
+    void parseFunctionABILocation(Dyninst::SymtabAPI::Symbol *, Dyninst::Architecture);
 
     /**
      * @brief Dump a corpus to asp 
@@ -60,39 +47,6 @@ namespace smeagle {
      * @brief Dump a corpus to yaml
      */
     void toYaml();
-
-    /**
-     * @brief Get the name of a symbol type from the enum int
-     * @param symbol the symbol object
-     */
-    std::string getStringSymbolType(Symbol* symbol);
-
-    /**
-     * @brief get the location offset for a parameter / variable
-     * @param param the parameter to get location offset for
-     */
-    std::string getParamLocationOffset(localVar * param);
-    
-    /**
-     * @brief Get a string representation of a location from a type
-     * @param regClass the RegisterClass
-     * @param order the order of the parameter
-     */
-    std::string getStringLocationFromRegisterClass(RegisterClass regClasses, int order);
-
-    /**
-     * @brief Get a RegisterClass based on a parameter type
-     * @param paramType the parameter (variable) type
-     */
-    std::vector <RegisterClass> getRegisterClassFromType(Type *paramType);
-
-    /**
-     * @brief Update the framebase based on the parameter type
-     * @param paramType the parameter (variable) type
-     * @param framebase the current location on the stack
-     */
-    int updateFramebaseFromType(Type * paramType, int framebase);
-
   };
 
 }  // namespace corpora

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -3,267 +3,25 @@
 //
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-#include <fmt/format.h>
-#include <smeagle/corpora.h>
-#include <regex>
+#include <string>
+#include <stdexcept>
 #include <iostream>
-#include <fmt/core.h>
 
-#include "Function.h"
 #include "Symtab.h"
 
-using namespace Dyninst;
-using namespace SymtabAPI;
+#include "smeagle/corpora.h"
+#include "parser/x86_64.hpp"
+#include "parser/ppc64le.hpp"
+#include "parser/aarch64.hpp"
+
 using namespace smeagle;
 
 Corpus::Corpus(std::string _library) : library(std::move(_library)) {};
 
-// Given a symbol, get a string representation of its type
-std::string Corpus::getStringSymbolType(Symbol *symbol) {
-  Symbol::SymbolType stype = symbol->getType();
-  std::string sname;
-
-  switch (stype) {
-    case (Symbol::SymbolType::ST_FUNCTION): {
-      sname = "function";
-      break;
-    }
-    case (Symbol::SymbolType::ST_UNKNOWN): {
-      sname = "unknown";
-      break;
-    }
-    case (Symbol::SymbolType::ST_OBJECT): {
-      sname = "object";
-      break;
-    }
-    case (Symbol::SymbolType::ST_SECTION): {
-      sname = "section";
-      break;
-    }
-    case (Symbol::SymbolType::ST_MODULE): {
-      sname = "module";
-      break;
-    }
-    case (Symbol::SymbolType::ST_TLS): {
-      sname = "tls";
-      break;
-    }
-    case (Symbol::SymbolType::ST_DELETED): {
-      sname = "deleted";
-      break;
-    }
-    case (Symbol::SymbolType::ST_INDIRECT): {
-      sname = "indirect";
-      break;
-    }
-    case (Symbol::SymbolType::ST_NOTYPE): {
-      sname = "notype";
-      break;
-    }
-  }
-  return sname;
-}
-
-// Get a framebase for a variable based on stack location and type
-int Corpus::updateFramebaseFromType(Type * paramType, int framebase){
-
-    // sizeof 16 with alignment bytes 16
-    std::regex check16("(__int128|long double|__float128|__m128)");
-
-    // sizeof 8 with alignment bytes 8
-    std::regex check8("(long|[*]|double|m_64|__int128)");
-
-    // sizeof 1 with alginment bytes 1
-    std::regex check1("(char|bool)");
-
-    // sizeof 2 with alignment bytes 2
-    std::regex check2("short");
-
-    // sizeof 4 with alignment bytes 4
-    std::regex check4("(int|enum|float)");
-
-    std::string paramTypeString = paramType->getName();
-
-    if (std::regex_search(paramTypeString, check16)){
-        framebase += 16;
-    } else if (std::regex_search(paramTypeString, check8)){
-        framebase += 8;
-    } else if (std::regex_search(paramTypeString, check1)){
-        framebase += 1;
-    } else if (std::regex_search(paramTypeString, check2)){
-        framebase += 2;
-    } else if (std::regex_search(paramTypeString, check4)){
-        framebase += 4;
-    } 
-    return framebase; 
-}
-
-// Get a location offset for a variable
-// This function is not used because LocationLists are not reliable
-std::string Corpus::getParamLocationOffset(localVar * param){
-    std::vector<VariableLocation> locs = param->getLocationLists();
-    std::stringstream result;
-
-    for (auto i = locs.begin(); i != locs.end(); ++i) {
-        VariableLocation current = *i;
-
-        // We only want to know where parameter is at the entrypoint
-        result << std::hex << current.lowPC << " to " << current.hiPC 
-               << " " << current.mr_reg.name() <<  " "
-               << std::dec << current.frameOffset;
-
-        break;
-    }
-           
-    return result.str();
-}
-
-
-// Get register class given the argument type
-std::vector <RegisterClass> Corpus::getRegisterClassFromType(Type *paramType) {
-
-  // We need a string version of the type
-  std::string paramTypeString = paramType->getName();
-
-  // Signed and unsigned Bool,char,short,int,long,long long, and pointers
-  std::regex checkinteger("(int|char|short|long|pointer|bool)");
-
-  // Is it a constant?
-  std::regex checkconstant("(const)");
-
-  // float,double,_Decimal32,_Decimal64and__m64are in class SSE.
-  std::regex checksse("(double|decimal|float|Decimal|m64)");
-
-  // __float128 and__m128are split into two halves, least significant SSE,
-  // most significant in SSEUP.
-  std::regex checksseup("(m128|float128)");
-
-  // The 64-bit mantissa of arguments of type long double belongs to classX87
-  // the 16-bit exponent plus 6 bytes of padding belongs to class X87UP
-  std::regex checklongdouble("(long|double)");
-
-  // A variable of type complex long double is classified as type COMPLEX_X87
-  std::regex checkcomplexlong("(complex long double)");
-
-  // We will return a vector of classes
-  std::vector <RegisterClass> regClasses;
-
-  // Does the type string match one of the types?
-  bool isinteger = (std::regex_search(paramTypeString, checkinteger));
-  bool isconst = (std::regex_search(paramTypeString, checkconstant));
-  bool issse = (std::regex_search(paramTypeString, checksse));
-  bool issseup = (std::regex_search(paramTypeString, checksseup));
-  bool islongdouble = (std::regex_search(paramTypeString, checklongdouble));
-  bool iscomplexlong = (std::regex_search(paramTypeString, checkcomplexlong));
-
-  // A parameter can have more than one class!
-  if (isconst) {
-    regClasses.push_back(RegisterClass::MEMORY);
-  }
-  if (issseup) {
-    regClasses.insert(regClasses.end(), {RegisterClass::SSE, RegisterClass::SSEUP});
-  } 
-  if (issse) {
-    regClasses.push_back(RegisterClass::SSE);
-  } 
-  if (isinteger) {
-    regClasses.push_back(RegisterClass::INTEGER);
-  } 
-  if (iscomplexlong) {
-    regClasses.push_back(RegisterClass::COMPLEX_X87);
-  }
-  if (islongdouble) {
-    regClasses.insert(regClasses.end(), {RegisterClass::X87, RegisterClass::X87UP});
-  } 
-  
-  // check if the length is 0, default to RegisterClass::NO_CLASS;
-  if (regClasses.size() == 0) {
-      regClasses.push_back(RegisterClass::NO_CLASS);
-  }
-
-  // The classification of aggregate (structures and arrays) and union types worksas follows:
-  // TODO need to look for struct / arrays?
-  // page 18 of abi document
-  return regClasses;
-}
-
-// Get a string location from a register class
-std::string Corpus::getStringLocationFromRegisterClass(RegisterClass regClass, int order) {
-
-  // Return a string representation of the register
-  std::string regString;
-
-  // If the class is memory, pass the argument on the stack
-  if (regClass == RegisterClass::MEMORY) {
-    regString = "stack";
-
-  // If the class is INTEGER, the next available register in sequence is used
-  } else if (regClass == RegisterClass::SSE) {
-    regString = "xmm" + std::to_string(order - 1);
-  } else if (regClass == RegisterClass::INTEGER) {
-    switch (order) {
-      case 1: {
-        regString = "%rdi";
-        break;
-      }
-      case 2: {
-        regString = "%rsi";
-        break;
-      }
-      case 3: {
-        regString = "%rdx";
-        break;
-      }
-      case 4: {
-        regString = "%rcx";
-        break;
-      }
-      case 5: {
-        regString = "%r8";
-        break;
-      }
-      case 6: {
-        regString = "%r9";
-        break;
-      }
-
-      // the document doesn't say it goes up this high
-      case 7: {
-        regString = "%r10";
-        break;
-      }
-      case 8: {
-        regString = "%r11";
-        break;
-      }
-      case 9: {
-        regString = "%r12";
-        break;
-      }
-      case 10: {
-        regString = "%r13";
-        break;
-      }
-      case 11: {
-        regString = "%r14";
-        break;
-      }
-      case 12: {
-        regString = "%r15";
-        break;
-      }
-      // Greater than 6 is stored in memory
-      default: { regString = "memory"; }
-    }
-  }
-
-  return regString;
-}
-
 // dump all Type Locations to asp
 void Corpus::toAsp() {
 
-    std::cout << "corpus(" << library << ")," << std::endl; 
+    std::cout << "corpus(" << library << ")," << std::endl;
     for (auto &typeloc : typelocs) {
 
         std::cout << "abi_typelocation(" << library << ", " << typeloc.parent
@@ -275,12 +33,12 @@ void Corpus::toAsp() {
 // dump all Type Locations to yaml output
 void Corpus::toYaml() {
 
-    std::cout << "library: \"" << library << "\"\nlocations: " << std::endl; 
+    std::cout << "library: \"" << library << "\"\nlocations: " << std::endl;
     for (auto &typeloc : typelocs) {
 
         std::cout << " - library: " << library << "\n   parent: " << typeloc.parent
                   << "\n   name: " << typeloc.name << "\n   type: " << typeloc.type
-                  << "\n   location: " <<  typeloc.location << "\n   register: " 
+                  << "\n   location: " <<  typeloc.location << "\n   register: "
                   << typeloc.reg << "\n" << std::endl;
     }
 }
@@ -289,7 +47,7 @@ void Corpus::toYaml() {
 // dump all Type Locations to json
 void Corpus::toJson() {
 
-    std::cout << "{ \"library\": \"" << library << "\", \"locations\": [" << std::endl; 
+    std::cout << "{ \"library\": \"" << library << "\", \"locations\": [" << std::endl;
     for (auto &typeloc : typelocs) {
 
         // Check if we are at the last entry (no comma) or not
@@ -299,64 +57,28 @@ void Corpus::toJson() {
         else {
             endcomma = ",";
         }
-        std::cout << "{\"library\": \"" << library << "\", \"parent\": \"" 
+        std::cout << "{\"library\": \"" << library << "\", \"parent\": \""
                   << typeloc.parent << "\", \"name\": \"" << typeloc.name << "\", \"type\": \""
-                  << typeloc.type << "\", \"location\": \"" << typeloc.location << "\", " 
+                  << typeloc.type << "\", \"location\": \"" << typeloc.location << "\", "
                   << "\"register\": \"" << typeloc.reg << "\"}"
                   << endcomma << std::endl;
     }
-    std::cout << "]}" << std::endl; 
+    std::cout << "]}" << std::endl;
 
 }
 
 // parse a function for parameters and abi location
-void Corpus::parseFunctionABILocation(Symbol *symbol) {
-  // Get the name and type of the symbol
-  std::string sname = symbol->getMangledName();
-  std::string stype = Corpus::getStringSymbolType(symbol);
-
-  Function *func = symbol->getFunction();
-  std::vector<localVar *> params;
-
-  // The function name looks equivalent to the symbol name
-  std::string fname = func->getName();
-
-  // Get parameters with types and names
-  if (func->getParams(params)) {
-
-    // We need to keep track of the order and framebase, which starts at 8
-    std::string framebaseStr;
-    int framebase = 8;
-    int order = 1;
-
-    for (auto &param : params) {
-      std::string paramName = param->getName();
-      Type *paramType = param->getType();
-
-      // Get register class based on type
-      std::vector <RegisterClass> regClasses = getRegisterClassFromType(paramType);
-
-      // Get register name from register classes
-//      std::string loc = getStringLocationFromRegisterClass(regClasses);
-
-      // This uses location lists, not reliable
-      // std::string locoffset = getParamLocationOffset(param);
-
-      // Create a new typelocation to parse later
-      TypeLocation typeloc;
-      typeloc.name = paramName;
-      typeloc.parent = fname;
-      typeloc.type = paramType->getName();
-     
-      // TODO how to determine if export/import?
-      typeloc.exportOrImport = "export";
-//      typeloc.reg = loc;
-      typeloc.location = "framebase+" + std::to_string(framebase);
-      typelocs.push_back (typeloc);
-      order += 1;
-
-      // Update the framebase for the next parameter based on the type
-      framebase = updateFramebaseFromType(paramType, framebase);      
+void Corpus::parseFunctionABILocation(Dyninst::SymtabAPI::Symbol *symbol, Dyninst::Architecture arch) {
+    switch (arch) {
+      case Dyninst::Architecture::Arch_x86_64:
+        typelocs = std::move(x86_64::parse_parameters(symbol));
+        break;
+      case Dyninst::Architecture::Arch_aarch64:
+        break;
+      case Dyninst::Architecture::Arch_ppc64:
+        break;
+      default:
+        throw std::runtime_error{"Unsupported architecture: " + std::to_string(arch)};
+        break;
     }
-  }
 }

--- a/source/corpora.cpp
+++ b/source/corpora.cpp
@@ -158,10 +158,10 @@ std::vector <RegisterClass> Corpus::getRegisterClassFromType(Type *paramType) {
 
   // A parameter can have more than one class!
   if (isconst) {
-    regClass.push_back(RegisterClass::MEMORY);
+    regClasses.push_back(RegisterClass::MEMORY);
   }
   if (issseup) {
-    regClasses.insert(regClass.end(), {RegisterClass::SSE, RegisterClass::SSE_UP});
+    regClasses.insert(regClasses.end(), {RegisterClass::SSE, RegisterClass::SSEUP});
   } 
   if (issse) {
     regClasses.push_back(RegisterClass::SSE);
@@ -173,11 +173,11 @@ std::vector <RegisterClass> Corpus::getRegisterClassFromType(Type *paramType) {
     regClasses.push_back(RegisterClass::COMPLEX_X87);
   }
   if (islongdouble) {
-    regClasses.insert(regClass.end(), {RegisterClass::X87, RegisterClass::X87_UP});
+    regClasses.insert(regClasses.end(), {RegisterClass::X87, RegisterClass::X87UP});
   } 
   
   // check if the length is 0, default to RegisterClass::NO_CLASS;
-  if (regClass.size() == 0) {
+  if (regClasses.size() == 0) {
       regClasses.push_back(RegisterClass::NO_CLASS);
   }
 
@@ -188,76 +188,76 @@ std::vector <RegisterClass> Corpus::getRegisterClassFromType(Type *paramType) {
 }
 
 // Get a string location from a register class
-std::string Corpus::getStringLocationFromRegisterClass(RegisterClass regClasses, int order) {
+std::string Corpus::getStringLocationFromRegisterClass(RegisterClass regClass, int order) {
 
   // Return a string representation of the register
   std::string regString;
 
   // If the class is memory, pass the argument on the stack
-  if (regClasses.size() == 1 && regClasses[0] == RegisterClass::Memory) {
+  if (regClass == RegisterClass::MEMORY) {
     regString = "stack";
 
   // If the class is INTEGER, the next available register in sequence is used
-  } else if (regClasses.size() == 1 && regClasses[0] == RegisterClass::SSE) {
-    loc = "xmm" + std::to_string(order - 1);
+  } else if (regClass == RegisterClass::SSE) {
+    regString = "xmm" + std::to_string(order - 1);
   } else if (regClass == RegisterClass::INTEGER) {
     switch (order) {
       case 1: {
-        loc = "%rdi";
+        regString = "%rdi";
         break;
       }
       case 2: {
-        loc = "%rsi";
+        regString = "%rsi";
         break;
       }
       case 3: {
-        loc = "%rdx";
+        regString = "%rdx";
         break;
       }
       case 4: {
-        loc = "%rcx";
+        regString = "%rcx";
         break;
       }
       case 5: {
-        loc = "%r8";
+        regString = "%r8";
         break;
       }
       case 6: {
-        loc = "%r9";
+        regString = "%r9";
         break;
       }
 
       // the document doesn't say it goes up this high
       case 7: {
-        loc = "%r10";
+        regString = "%r10";
         break;
       }
       case 8: {
-        loc = "%r11";
+        regString = "%r11";
         break;
       }
       case 9: {
-        loc = "%r12";
+        regString = "%r12";
         break;
       }
       case 10: {
-        loc = "%r13";
+        regString = "%r13";
         break;
       }
       case 11: {
-        loc = "%r14";
+        regString = "%r14";
         break;
       }
       case 12: {
-        loc = "%r15";
+        regString = "%r15";
         break;
       }
       // Greater than 6 is stored in memory
-      default: { loc = "memory"; }
+      default: { regString = "memory"; }
     }
   }
 
-  return loc;
+  return regString;
 }
 
 // dump all Type Locations to asp
@@ -337,7 +337,7 @@ void Corpus::parseFunctionABILocation(Symbol *symbol) {
       std::vector <RegisterClass> regClasses = getRegisterClassFromType(paramType);
 
       // Get register name from register classes
-      std::string loc = getStringLocationFromRegisterClass(regClasses);
+//      std::string loc = getStringLocationFromRegisterClass(regClasses);
 
       // This uses location lists, not reliable
       // std::string locoffset = getParamLocationOffset(param);
@@ -350,7 +350,7 @@ void Corpus::parseFunctionABILocation(Symbol *symbol) {
      
       // TODO how to determine if export/import?
       typeloc.exportOrImport = "export";
-      typeloc.reg = loc;
+//      typeloc.reg = loc;
       typeloc.location = "framebase+" + std::to_string(framebase);
       typelocs.push_back (typeloc);
       order += 1;

--- a/source/detail/parser/aarch64.cpp
+++ b/source/detail/parser/aarch64.cpp
@@ -1,0 +1,10 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#include "aarch64.hpp"
+
+namespace smeagle::aarch64 {
+
+}  // namespace smeagle::aarch64

--- a/source/detail/parser/aarch64.hpp
+++ b/source/detail/parser/aarch64.hpp
@@ -1,0 +1,9 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#pragma once
+
+namespace smeagle::aarch64 {
+}  // namespace smeagle::aarch64

--- a/source/detail/parser/ppc64le.cpp
+++ b/source/detail/parser/ppc64le.cpp
@@ -1,0 +1,10 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#include "ppc64le.hpp"
+
+namespace smeagle::ppc64le {
+
+}  // namespace smeagle::ppc64le

--- a/source/detail/parser/ppc64le.hpp
+++ b/source/detail/parser/ppc64le.hpp
@@ -1,0 +1,10 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#pragma once
+
+namespace smeagle::ppc64le {
+
+}  // namespace smeagle::ppc64le

--- a/source/detail/parser/x86_64.cpp
+++ b/source/detail/parser/x86_64.cpp
@@ -1,0 +1,330 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#include <iostream>
+#include <regex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "smeagle/TypeLocation.h"
+
+#include "Function.h"
+#include "Symtab.h"
+
+namespace smeagle::x86_64 {
+
+  namespace st = Dyninst::SymtabAPI;
+
+  // A register class for AMD64 is defined on page 16 of the System V abi pdf
+  enum RegisterClass {
+    INTEGER,     // Integer types that fit into one of the general purpose registers
+    SSE,         // Types that fit into an SSE register
+    SSEUP,       // ^.. and can ve passed and returned in he most significant half of it
+    X87,         // Types that will be returned via the x87 FPU
+    X87UP,       // ^
+    COMPLEX_X87, // Types that will be returned via the x87 FPU
+    NO_CLASS,    // Initalizer in the algorithms, used for padding and empty
+                 // tructures and unions
+    MEMORY       // Types that will be passed and returned in memory via the stack
+  };
+
+  // Given a symbol, get a string representation of its type
+  std::string getStringSymbolType(st::Symbol *symbol) {
+    st::Symbol::SymbolType stype = symbol->getType();
+    std::string sname;
+
+    switch (stype) {
+      case (st::Symbol::SymbolType::ST_FUNCTION): {
+        sname = "function";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_UNKNOWN): {
+        sname = "unknown";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_OBJECT): {
+        sname = "object";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_SECTION): {
+        sname = "section";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_MODULE): {
+        sname = "module";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_TLS): {
+        sname = "tls";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_DELETED): {
+        sname = "deleted";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_INDIRECT): {
+        sname = "indirect";
+        break;
+      }
+      case (st::Symbol::SymbolType::ST_NOTYPE): {
+        sname = "notype";
+        break;
+      }
+    }
+    return sname;
+  }
+
+  // Get a framebase for a variable based on stack location and type
+  int updateFramebaseFromType(st::Type * paramType, int framebase){
+
+      // sizeof 16 with alignment bytes 16
+      std::regex check16("(__int128|long double|__float128|__m128)");
+
+      // sizeof 8 with alignment bytes 8
+      std::regex check8("(long|[*]|double|m_64|__int128)");
+
+      // sizeof 1 with alginment bytes 1
+      std::regex check1("(char|bool)");
+
+      // sizeof 2 with alignment bytes 2
+      std::regex check2("short");
+
+      // sizeof 4 with alignment bytes 4
+      std::regex check4("(int|enum|float)");
+
+      std::string paramTypeString = paramType->getName();
+
+      if (std::regex_search(paramTypeString, check16)){
+          framebase += 16;
+      } else if (std::regex_search(paramTypeString, check8)){
+          framebase += 8;
+      } else if (std::regex_search(paramTypeString, check1)){
+          framebase += 1;
+      } else if (std::regex_search(paramTypeString, check2)){
+          framebase += 2;
+      } else if (std::regex_search(paramTypeString, check4)){
+          framebase += 4;
+      }
+      return framebase;
+  }
+
+  // Get a location offset for a variable
+  // This function is not used because LocationLists are not reliable
+  std::string getParamLocationOffset(st::localVar * param){
+      std::vector<Dyninst::VariableLocation> locs = param->getLocationLists();
+      std::stringstream result;
+
+      for (auto i = locs.begin(); i != locs.end(); ++i) {
+          Dyninst::VariableLocation current = *i;
+
+          // We only want to know where parameter is at the entrypoint
+          result << std::hex << current.lowPC << " to " << current.hiPC
+                 << " " << current.mr_reg.name() <<  " "
+                 << std::dec << current.frameOffset;
+
+          break;
+      }
+
+      return result.str();
+  }
+
+
+  // Get register class given the argument type
+  std::vector <RegisterClass> getRegisterClassFromType(st::Type *paramType) {
+
+    // We need a string version of the type
+    std::string paramTypeString = paramType->getName();
+
+    // Signed and unsigned Bool,char,short,int,long,long long, and pointers
+    std::regex checkinteger("(int|char|short|long|pointer|bool)");
+
+    // Is it a constant?
+    std::regex checkconstant("(const)");
+
+    // float,double,_Decimal32,_Decimal64and__m64are in class SSE.
+    std::regex checksse("(double|decimal|float|Decimal|m64)");
+
+    // __float128 and__m128are split into two halves, least significant SSE,
+    // most significant in SSEUP.
+    std::regex checksseup("(m128|float128)");
+
+    // The 64-bit mantissa of arguments of type long double belongs to classX87
+    // the 16-bit exponent plus 6 bytes of padding belongs to class X87UP
+    std::regex checklongdouble("(long|double)");
+
+    // A variable of type complex long double is classified as type COMPLEX_X87
+    std::regex checkcomplexlong("(complex long double)");
+
+    // We will return a vector of classes
+    std::vector <RegisterClass> regClasses;
+
+    // Does the type string match one of the types?
+    bool isinteger = (std::regex_search(paramTypeString, checkinteger));
+    bool isconst = (std::regex_search(paramTypeString, checkconstant));
+    bool issse = (std::regex_search(paramTypeString, checksse));
+    bool issseup = (std::regex_search(paramTypeString, checksseup));
+    bool islongdouble = (std::regex_search(paramTypeString, checklongdouble));
+    bool iscomplexlong = (std::regex_search(paramTypeString, checkcomplexlong));
+
+    // A parameter can have more than one class!
+    if (isconst) {
+      regClasses.push_back(RegisterClass::MEMORY);
+    }
+    if (issseup) {
+      regClasses.insert(regClasses.end(), {RegisterClass::SSE, RegisterClass::SSEUP});
+    }
+    if (issse) {
+      regClasses.push_back(RegisterClass::SSE);
+    }
+    if (isinteger) {
+      regClasses.push_back(RegisterClass::INTEGER);
+    }
+    if (iscomplexlong) {
+      regClasses.push_back(RegisterClass::COMPLEX_X87);
+    }
+    if (islongdouble) {
+      regClasses.insert(regClasses.end(), {RegisterClass::X87, RegisterClass::X87UP});
+    }
+
+    // check if the length is 0, default to RegisterClass::NO_CLASS;
+    if (regClasses.size() == 0) {
+        regClasses.push_back(RegisterClass::NO_CLASS);
+    }
+
+    // The classification of aggregate (structures and arrays) and union types worksas follows:
+    // TODO need to look for struct / arrays?
+    // page 18 of abi document
+    return regClasses;
+  }
+
+  // Get a string location from a register class
+  std::string getStringLocationFromRegisterClass(RegisterClass regClass, int order) {
+
+    // Return a string representation of the register
+    std::string regString;
+
+    // If the class is memory, pass the argument on the stack
+    if (regClass == RegisterClass::MEMORY) {
+      regString = "stack";
+
+    // If the class is INTEGER, the next available register in sequence is used
+    } else if (regClass == RegisterClass::SSE) {
+      regString = "xmm" + std::to_string(order - 1);
+    } else if (regClass == RegisterClass::INTEGER) {
+      switch (order) {
+        case 1: {
+          regString = "%rdi";
+          break;
+        }
+        case 2: {
+          regString = "%rsi";
+          break;
+        }
+        case 3: {
+          regString = "%rdx";
+          break;
+        }
+        case 4: {
+          regString = "%rcx";
+          break;
+        }
+        case 5: {
+          regString = "%r8";
+          break;
+        }
+        case 6: {
+          regString = "%r9";
+          break;
+        }
+
+        // the document doesn't say it goes up this high
+        case 7: {
+          regString = "%r10";
+          break;
+        }
+        case 8: {
+          regString = "%r11";
+          break;
+        }
+        case 9: {
+          regString = "%r12";
+          break;
+        }
+        case 10: {
+          regString = "%r13";
+          break;
+        }
+        case 11: {
+          regString = "%r14";
+          break;
+        }
+        case 12: {
+          regString = "%r15";
+          break;
+        }
+        // Greater than 6 is stored in memory
+        default: { regString = "memory"; }
+      }
+    }
+
+    return regString;
+  }
+
+  std::vector<TypeLocation> parse_parameters(st::Symbol *symbol) {
+	  // Get the name and type of the symbol
+	  std::string sname = symbol->getMangledName();
+	  std::string stype = getStringSymbolType(symbol);
+
+	  st::Function *func = symbol->getFunction();
+	  std::vector<st::localVar *> params;
+
+	  // The function name looks equivalent to the symbol name
+	  std::string fname = func->getName();
+
+	  std::vector<TypeLocation> typelocs;
+
+	  // Get parameters with types and names
+	  if (func->getParams(params)) {
+
+	    // We need to keep track of the order and framebase, which starts at 8
+	    std::string framebaseStr;
+	    int framebase = 8;
+	    int order = 1;
+
+	    for (auto &param : params) {
+	      std::string paramName = param->getName();
+	      st::Type *paramType = param->getType();
+
+	      // Get register class based on type
+	      std::vector <RegisterClass> regClasses = getRegisterClassFromType(paramType);
+
+	      // Get register name from register classes
+	//      std::string loc = getStringLocationFromRegisterClass(regClasses);
+
+	      // This uses location lists, not reliable
+	      // std::string locoffset = getParamLocationOffset(param);
+
+	      // Create a new typelocation to parse later
+	      TypeLocation typeloc;
+	      typeloc.name = paramName;
+	      typeloc.parent = fname;
+	      typeloc.type = paramType->getName();
+
+	      // TODO how to determine if export/import?
+	      typeloc.exportOrImport = "export";
+	//      typeloc.reg = loc;
+	      typeloc.location = "framebase+" + std::to_string(framebase);
+	      typelocs.push_back(typeloc);
+	      order += 1;
+
+	      // Update the framebase for the next parameter based on the type
+	      framebase = updateFramebaseFromType(paramType, framebase);
+	    }
+	  }
+	  return typelocs;
+  }
+
+}  // namespace smeagle::x86_64

--- a/source/detail/parser/x86_64.hpp
+++ b/source/detail/parser/x86_64.hpp
@@ -1,0 +1,17 @@
+// Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+// Spack Project Developers. See the top-level COPYRIGHT file for details.
+//
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+#pragma once
+
+#include <vector>
+
+#include "Symtab.h"
+
+#include "smeagle/TypeLocation.h"
+
+namespace smeagle::x86_64 {
+
+  std::vector<TypeLocation> parse_parameters(Dyninst::SymtabAPI::Symbol *symbol);
+}  // namespace smeagle::x86_64

--- a/source/smeagle.cpp
+++ b/source/smeagle.cpp
@@ -56,7 +56,7 @@ int Smeagle::parse(FormatCode fmt) {
     if (symbol->isInDynSymtab()) {
       // If It's a function, parse the parameters
       if (symbol->isFunction()) {
-        corpus.parseFunctionABILocation(symbol);
+        corpus.parseFunctionABILocation(symbol, obj->getArchitecture());
 
         // The symbol is something else (we likely want a subset of these?)
       }  // else {


### PR DESCRIPTION
These changes are purely structural. Once we get them merged from refactor/register-classes into main, we can refactor the functionality away from location lists.