### PR TITLE
Adding check to see if size is > 8x8bytes, in which case goes to MEMORY

### DIFF
--- a/source/parser/x86_64/classifiers.hpp
+++ b/source/parser/x86_64/classifiers.hpp
@@ -79,25 +79,25 @@ namespace smeagle::x86_64 {
   }
 
   inline classification classify(st::typeStruct *t) {
-    const auto size = t->getSize() * 8;
+    const auto size = t->getSize();
 
-    // If an object is larger than eight eightbyes (i.e., 512 bits) class MEMORY.
-    if (size > 512) {
+    // If an object is larger than eight eightbyes (i.e., 64) class MEMORY.
+    if (size > 64) {
       return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, "Struct"};
     }
 
     return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, "Struct"};
   }
   inline classification classify(st::typeUnion *t) {
-    const auto size = t->getSize() * 8;
-    if (size > 512) {
+    const auto size = t->getSize();
+    if (size > 64) {
       return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, "Union"};
     }
     return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, "Union"};
   }
   inline classification classify(st::typeArray *t) {
-    const auto size = t->getSize() * 8;
-    if (size > 512) {
+    const auto size = t->getSize();
+    if (size > 64) {
       return {RegisterClass::MEMORY, RegisterClass::NO_CLASS, "Array"};
     }
     return {RegisterClass::INTEGER, RegisterClass::NO_CLASS, "Array"};


### PR DESCRIPTION
This is for half of the first bullet here:

![image](https://user-images.githubusercontent.com/814322/131192199-6041d0a4-e346-4834-98e3-76fc4e0962cf.png)

We will eventually want to refactor this to not be so redundant, but this should work for now.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>